### PR TITLE
fix: resolve TypeScript build failure

### DIFF
--- a/web/tsconfig.node.json
+++ b/web/tsconfig.node.json
@@ -7,7 +7,7 @@
     "allowSyntheticDefaultImports": true,
     "strict": true,
     "target": "ES2020",
-    "types": ["node", "vitest"],
+    "types": ["vitest"],
     "noEmit": true
   },
   "include": ["vite.config.ts", "vitest.setup.ts"],


### PR DESCRIPTION
## Summary
- remove the unnecessary Node type reference from the node TypeScript config to prevent missing type definition errors

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69184c2b8688832a9be7991d5841a5a7)